### PR TITLE
Add type checking via typescript

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+
+  "compilerOptions": {
+    "target": "es2017",
+    "checkJs": true
+  },
+  "include": ["src/**/*.js"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -766,7 +766,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -2982,6 +2983,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -3023,6 +3025,7 @@
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -3031,7 +3034,8 @@
           "version": "0.0.8",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4494,6 +4498,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
+      "dev": true
+    },
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -4875,7 +4885,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "yargs": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "build": "gulp",
     "prepare": "gulp",
-    "size": "node -e \"process.stdout.write('gzip size: ')\" && gzip-size dist/erste.js"
+    "size": "node -e \"process.stdout.write('gzip size: ')\" && gzip-size dist/erste.js",
+    "ts-type-check": "tsc --noEmit --project jsconfig.json"
   },
   "author": "Armagan Amcalar <armagan@amcalar.com>",
   "license": "MIT",
@@ -29,6 +30,7 @@
     "gulp-clean-css": "^4.0.0",
     "gulp-concat-css": "^3.1.0",
     "gulp-sourcemaps": "^2.4.1",
-    "gulp-watch": "^5.0.1"
+    "gulp-watch": "^5.0.1",
+    "typescript": "^3.2.4"
   }
 }

--- a/src/components/infinite-scroll/infinite-scroll.js
+++ b/src/components/infinite-scroll/infinite-scroll.js
@@ -14,7 +14,7 @@ class InfiniteScroll extends Component {
      * done loading new items, it should reset this InfiniteScrollComponent
      * with the reset() method.
      *
-     * @param {!Element=} opt_el Optional element to track its scroll.
+     * @param {!HTMLElement=} opt_el Optional element to track its scroll.
      */
     constructor(opt_el) {
         super();
@@ -26,6 +26,7 @@ class InfiniteScroll extends Component {
         this.EventType = this.model.EventType;
 
         this.scrollListener_ = null;
+        /** @type {HTMLElement} */
         this.scrollEl = null;
 
         /**
@@ -79,7 +80,7 @@ class InfiniteScroll extends Component {
      *
      * Registers an element to track its scroll. This can be used for lazily introducing an element to track.
      *
-     * @param {?Element} el Element to track.
+     * @param {?HTMLElement} el Element to track.
      */
     register(el) {
         if (!el) return;

--- a/src/components/navbar/navbar.js
+++ b/src/components/navbar/navbar.js
@@ -77,6 +77,6 @@ class NavBar extends Component {
 /**
 * @typedef {{hasBackButton: boolean, hasMenuButton: boolean, title: string}}
 */
-NavBar.NavBarOptions;
+NavBar.NavBarOptions = null;
 
 export default NavBar;

--- a/src/components/pull-to-refresh/pull-to-refresh.js
+++ b/src/components/pull-to-refresh/pull-to-refresh.js
@@ -13,7 +13,7 @@ export default class PullToRefresh extends Component {
      * done with refreshing, it should reset this P2RComponent with the
      * reset() method.
      *
-     * @param {!Element=} opt_el Optional element to track its scroll.
+     * @param {!HTMLElement=} opt_el Optional element to track its scroll.
      */
     constructor(opt_el) {
         super();
@@ -52,8 +52,8 @@ export default class PullToRefresh extends Component {
             this.containerEl.style.transform = `translateY(${this.height}px)`;
             this.containerEl.style.transition = '800ms cubic-bezier(.41,1,.1,1)';
 
-            if (spinner) spinner.style.opacity = 1;
-            if (arrow) arrow.style.opacity = 0;
+            if (spinner) spinner.style.opacity = '1';
+            if (arrow) arrow.style.opacity = '0';
 
             this.emit(this.model.EventType.SHOULD_REFRESH);
         });
@@ -65,7 +65,7 @@ export default class PullToRefresh extends Component {
      */
     onAfterRender() {
         super.onAfterRender();
-        if (!this.scrollEl) this.register(this.el.parentElement);
+        if (!this.scrollEl) this.register(/** @type {HTMLElement} */(this.el.parentElement));
     };
 
 
@@ -85,10 +85,10 @@ export default class PullToRefresh extends Component {
         var spinner = this.$(this.mappings.SPINNER);
         var arrow = this.$(this.mappings.ARROW);
 
-        if (spinner) spinner.style.opacity = 0;
+        if (spinner) spinner.style.opacity = '0';
 
         setTimeout(() => {
-            if (arrow) arrow.style.opacity = 1;
+            if (arrow) arrow.style.opacity = '1';
         }, 500);
 
         this.model.reset();
@@ -100,8 +100,8 @@ export default class PullToRefresh extends Component {
      *
      * Registers an element to track its scroll. This can be used for lazily introducing an element to track.
      *
-     * @param {?Element} scrollEl Element to track.
-     * @param {?Element=} containerEl Element to offset during activity.
+     * @param {?HTMLElement} scrollEl Element to track.
+     * @param {?HTMLElement=} containerEl Element to offset during activity.
      */
     register(scrollEl, containerEl) {
         if (!scrollEl) return;
@@ -139,7 +139,7 @@ export default class PullToRefresh extends Component {
         this.checkShouldRefresh();
 
         var rot = 0,
-            scroll = -(e.target && e.target.scrollTop || 0),
+            scroll = -(e.target && /** @type {HTMLElement} */(e.target).scrollTop || 0),
             pos = this.arrowOffset + Math.pow(scroll, 0.75),
             rotationThreshold = this.threshold - 60;
 

--- a/src/lib/base/component.js
+++ b/src/lib/base/component.js
@@ -61,7 +61,7 @@ export default class Component extends EventEmitter {
         this.id_ = ComponentManager.getUid();
 
         /**
-         * @type {?Element}
+         * @type {?HTMLElement}
          *
          * @private
          */
@@ -142,8 +142,8 @@ export default class Component extends EventEmitter {
     get el() {
         let rv = this.element_;
         if (!rv) {
-            rv = this.element_ = document.getElementById(this.id) ||
-                ComponentManager.createElement(this.toString());
+            rv = this.element_ = /** @type {!HTMLElement} */ (document.getElementById(this.id) ||
+                 (ComponentManager.createElement(this.toString())));
         }
 
         return rv;
@@ -223,12 +223,12 @@ export default class Component extends EventEmitter {
      * `el.querySelector`.
      *
      * @param {string} selector Selector
-     * @return {?Element}
+     * @return {?HTMLElement}
      */
     $(selector) {
         let rv = null, el = this.element_;
 
-        if (el) rv = selector == undefined ? el : el.querySelector(selector);
+        if (el) rv = selector == undefined ? el : /** @type {HTMLElement} */(el.querySelector(selector));
 
         return rv;
     }
@@ -241,7 +241,7 @@ export default class Component extends EventEmitter {
      * the result. May be called with an optional index to indicate where the
      * DOM element of this {@link Component} should be inserted in the parent.
      *
-     * @param {!Element} rootEl Root element to render this component in.
+     * @param {!HTMLElement} rootEl Root element to render this component in.
      * @param {number=} opt_index The index of this component within the parent
      * component. This may be used to render a new child before an existing
      * child in the parent.
@@ -254,11 +254,12 @@ export default class Component extends EventEmitter {
         if (this.rendered_) return true;
 
         if (!this.element_) {
-            var el = document.getElementById(this.id);
+
+            var el = /** @type {HTMLElement} */ (document.getElementById(this.id));
             if (!el && !rootEl) return false;
 
             if (el) {
-                rootEl = /** @type {!Element} */(el.parentElement);
+                rootEl = /** @type {!HTMLElement} */(el.parentElement);
                 if (!opt_index) {
                     this.element_ = el;
                     this.rendered_ = true;
@@ -286,7 +287,7 @@ export default class Component extends EventEmitter {
         if (!this.rendered_) {
             var el = document.getElementById(this.id);
             if (el) {
-                this.element_ = el;
+                this.element_ = /** @type {HTMLElement} */(el);
                 this.rendered_ = true;
                 this.onAfterRender();
             }
@@ -365,5 +366,7 @@ export default class Component extends EventEmitter {
     /**
      * @export
      */
-    get events() {}
+    get events() {
+      return {}
+    }
 }

--- a/src/lib/base/eventemitter3.js
+++ b/src/lib/base/eventemitter3.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /*!
  * EventEmitter3
  *

--- a/src/lib/base/gesture-handler.js
+++ b/src/lib/base/gesture-handler.js
@@ -40,7 +40,7 @@ export default class GestureHandler {
     /**
      * Tracks and fires gestures on touch enabled devices.
      *
-     * @param {!Element=} opt_el Provided, gesture handler will track gesture
+     * @param {!HTMLElement=} opt_el Provided, gesture handler will track gesture
      *                           events on this element. The default
      *                           value is document.body; but an optional
      *                           root element is inevitable for iframe's.

--- a/src/lib/view-manager.js
+++ b/src/lib/view-manager.js
@@ -62,7 +62,7 @@ class ViewManager {
         /**
          * @private
          *
-         * @type {?Element}
+         * @type {?HTMLElement}
          */
         this.rootEl_ = null;
 
@@ -122,7 +122,7 @@ class ViewManager {
                 this.rootEl_ = rootView.el;
         }
         else
-            this.rootEl_ = /** @type {?Element} */(this.root_) || document.body;
+            this.rootEl_ = /** @type {?HTMLElement} */(this.root_) || document.body;
 
         this.initTouchEvents_();
     }
@@ -306,7 +306,7 @@ class ViewManager {
             return;
         }
 
-        view.el.style.zIndex = view.index;
+        view.el.style.zIndex = String(view.index);
         view.el.style.transform = translation;
 
         this.state_ = ViewManager.State.DEFAULT;
@@ -551,7 +551,7 @@ class ViewManager {
      */
     toggleSidebar_(state) {
         var currentView = this.currentView,
-            sidebar = document.querySelector('sidebar');
+            sidebar = /** @type {HTMLElement} */(document.querySelector('sidebar'));
 
         requestAnimationFrame(() => {
             currentView.el.style.transitionDuration = '0.35s';
@@ -563,7 +563,7 @@ class ViewManager {
             if (!state) {
                 currentViewX = '0';
                 sidebarX = '100%';
-                sidebarZ = 0;
+                sidebarZ = '0';
                 this.hideSidebarTimeout_ = setTimeout(() => {
                     if (this.state_ == ViewManager.State.DEFAULT)
                         sidebar.style.transform = `translate3d(${sidebarX}, 0, ${sidebarZ})`;
@@ -600,7 +600,8 @@ class ViewManager {
          do not call event.preventDefault(). */
         e.preventDefault();
 
-        var sidebar = document.querySelector('sidebar');
+
+        var sidebar = /** @type {HTMLElement} */ (document.querySelector('sidebar'));
         var currentView = this.currentView;
         var currentViewDiff = clientX - this.firstX_;
 
@@ -649,6 +650,7 @@ ViewManager.prototype.topIndex_ = 1;
 window.requestAnimationFrame = (() => {
     return window.requestAnimationFrame ||
         window.webkitRequestAnimationFrame ||
+        // @ts-ignore
         window.mozRequestAnimationFrame ||
         function(callback) {
             window.setTimeout(callback, 1000 / 60);

--- a/src/lib/view.js
+++ b/src/lib/view.js
@@ -64,14 +64,14 @@ export default class View extends Component {
      *
      * @override
      *
-     * @param {?Element=} opt_rootEl=document.body Root element
+     * @param {?HTMLElement=} opt_rootEl=document.body Root element
      * to render this view in.
      * @param {number=} opt_index The index of this view in z-axis.
      */
     render(opt_rootEl = document.body, opt_index = 0) {
         this.index = opt_index;
 
-        return super.render(/** @type {!Element} */(opt_rootEl));
+        return super.render(/** @type {!HTMLElement} */(opt_rootEl));
     }
 
 
@@ -93,7 +93,7 @@ export default class View extends Component {
     onAfterRender() {
         super.onAfterRender();
 
-        this.el.style.zIndex = this.index;
+        this.el.style.zIndex = String(this.index);
         this.el.style.transform = `translate3d(0, 0, ${this.index}px)`;
     }
 
@@ -165,7 +165,7 @@ export default class View extends Component {
         if (!View.width_) {
             var bodyStyle = window.getComputedStyle(document.body, null);
 
-            var width = parseInt(bodyStyle && bodyStyle.width || 0, 10);
+            var width = parseInt(bodyStyle && bodyStyle.width || '0', 10);
 
             View.width_ = width;
             return View.width_;
@@ -176,6 +176,9 @@ export default class View extends Component {
     }
 }
 
+/**
+ * @static @type {?number} */
+View.width_ = null
 
 /**
  * @export


### PR DESCRIPTION
With this change, editors using language services VS Code don't show any errors

Had to explicitly typecast in a few places to make both Closure and TypeScript compilers happy.

The main change seems to be that TypeScript and Closure treats Element and HTMLElement differently. I am not really sure about the consequences of changing all Element types to HTMLElement.