### PR TITLE
separate back gesture animation from backGestureTouchMove method

### DIFF
--- a/src/lib/view-manager.js
+++ b/src/lib/view-manager.js
@@ -472,16 +472,11 @@ class ViewManager {
         var viewWidth = View.WIDTH;
         var lastViewDiff = Math.floor(math.lerp(-viewWidth * 0.3, 0, currentViewDiff / (viewWidth - this.firstX_)));
         var boxShadow = Math.floor(math.lerp(1, 0, currentViewDiff / (viewWidth - this.firstX_)) * 5) / 5;
+        var currentViewIndex = currentView.index
         if (currentViewDiff < 0) return;
 
-        window.requestAnimationFrame(() => {
-            currentView.el.style.transitionDuration = '0s';
-            lastView.el.style.transitionDuration = '0s';
-            currentView.el.style.transform = `translate3d(${currentViewDiff}px, 0, ${currentView.index}px)`;
-            lastView.el.style.transform = `translate3d(${lastViewDiff}px, 0, ${currentView.index - 1}px)`;
-
-            currentView.el.style['boxShadow'] = `0px 0 24px rgba(0, 0, 0, ${boxShadow})`;
-        });
+        lastView.backGestureTouchMoveLastViewAnimation({lastViewDiff, currentViewIndex})
+        currentView.backGestureTouchMoveCurrentViewAnimation({currentViewDiff, boxShadow})
     }
 
 

--- a/src/lib/view.js
+++ b/src/lib/view.js
@@ -182,6 +182,22 @@ export default class View extends Component {
         }
     }
 
+    backGestureTouchMoveLastViewAnimation({lastViewDiff,currentViewIndex}){
+        window.requestAnimationFrame(() => {
+            this.el.style.transitionDuration = '0s';
+            this.el.style.transform = `translate3d(${lastViewDiff}px, 0, ${currentViewIndex - 1}px)`;
+        });
+    }
+
+    backGestureTouchMoveCurrentViewAnimation({currentViewDiff, boxShadow}){
+        window.requestAnimationFrame(() => {
+            this.el.style.transitionDuration = '0s';
+            this.el.style.transform = `translate3d(${currentViewDiff}px, 0, ${this.index}px)`;
+
+            this.el.style['boxShadow'] = `0px 0 24px rgba(0, 0, 0, ${boxShadow})`;
+        });
+    }
+
 
     /**
      * Default template for views. Uses a custom element `<view>`, which should


### PR DESCRIPTION
Current behavior on `backGestureTouchMove` is to animate the `lastView` as the `currentView` is being dragged to return to the last view, however it is possible that users would like to perform a specific animation or no animation at all for either view. Because of this I added `backGestureTouchMoveLastViewAnimation` and `backGestureTouchMoveCurrentViewAnimation` to handle each case.