### PR TITLE
Inject fallback click event for non-touch devices

### DIFF
--- a/src/lib/base/component-manager.js
+++ b/src/lib/base/component-manager.js
@@ -91,7 +91,7 @@ function decorateEvents(comp) {
         events = originalPrototype.events;
     }
 
-    if (!('ontouchstart' in window) && !events['click'] && events['touchend'] || events['tap']) {
+    if (!('ontouchstart' in window) && !events['click'] && (events['touchend'] || events['tap'])) {
         injectFallbackMouseEvents(events);
     }
 

--- a/src/lib/base/component-manager.js
+++ b/src/lib/base/component-manager.js
@@ -65,6 +65,27 @@ const nonBubblingEventsMap = {
 const handlerMethodPattern = new RegExp(`^(${events.join('|')}|${Object.keys(nonBubblingEventsMap).join('|')}) (.*)`);
 
 /**
+ * Injects fallback mouse events for non-touch devices to events object.
+ * 
+ * @param {!Object} events
+ */
+function injectFallbackMouseEvents(events) {
+    const fallbackableEvents = ['touchend', 'tap'];
+
+    const _events = { ...events };
+
+    fallbackableEvents.forEach(eventType => {
+        if (events['click'] || !events[eventType]) {
+            return;
+        }
+
+        _events['click'] = _events[eventType];
+    });
+
+    return _events;
+}
+
+/**
  * Fills events object of given component class from method names that match event handler pattern.
  *
  * @suppress {strictMissingProperties}
@@ -82,6 +103,10 @@ function decorateEvents(comp) {
 
     if (originalPrototype.events) {
         events = originalPrototype.events;
+    }
+
+    if (!('ontouchstart' in window)) {
+        events = injectFallbackMouseEvents(events);
     }
 
     const methods = [];

--- a/src/lib/base/component-manager.js
+++ b/src/lib/base/component-manager.js
@@ -66,23 +66,9 @@ const handlerMethodPattern = new RegExp(`^(${events.join('|')}|${Object.keys(non
 
 /**
  * Injects fallback mouse events for non-touch devices to events object.
- * 
- * @param {!Object} events
  */
 function injectFallbackMouseEvents(events) {
-    const fallbackableEvents = ['touchend', 'tap'];
-
-    const _events = { ...events };
-
-    fallbackableEvents.forEach(eventType => {
-        if (events['click'] || !events[eventType]) {
-            return;
-        }
-
-        _events['click'] = _events[eventType];
-    });
-
-    return _events;
+    events['click'] = events['touchend'] || events['tap'];
 }
 
 /**
@@ -105,8 +91,8 @@ function decorateEvents(comp) {
         events = originalPrototype.events;
     }
 
-    if (!('ontouchstart' in window)) {
-        events = injectFallbackMouseEvents(events);
+    if (!('ontouchstart' in window) && !events['click']) {
+        injectFallbackMouseEvents(events);
     }
 
     const methods = [];

--- a/src/lib/base/component-manager.js
+++ b/src/lib/base/component-manager.js
@@ -91,7 +91,7 @@ function decorateEvents(comp) {
         events = originalPrototype.events;
     }
 
-    if (!('ontouchstart' in window) && !events['click']) {
+    if (!('ontouchstart' in window) && !events['click'] && events['touchend'] || events['tap']) {
         injectFallbackMouseEvents(events);
     }
 


### PR DESCRIPTION
Hi,

This PR solves the issue https://github.com/dashersw/erste/issues/11 partially. 
It is a quick hack that enables user to click buttons with touchend and tap events with Desktop browser.

If we want to enable near-full fledged mobile UX experience with mouse events, I think we should implement something like MouseEventHandler class and handle everything there.